### PR TITLE
Re-add delay for motor init on MK4i modules

### DIFF
--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -35,6 +35,14 @@ public class Swerve extends SubsystemBase {
             new SwerveModule(3, Constants.Swerve.Mod3.constants)
         };
 
+        /*
+        * By pausing init for a second before setting module offsets, we avoid a bug
+        * with inverting motors.
+        * See https://github.com/Team364/BaseFalconSwerve/issues/8 for more info.
+        */
+        Timer.delay(1.0);
+        resetModulesToAbsolute();
+        
         swerveOdometry = new SwerveDriveOdometry(Constants.Swerve.swerveKinematics, getGyroYaw(), getModulePositions());
     }
 

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -17,6 +17,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj.Timer;
 
 public class Swerve extends SubsystemBase {
     public SwerveDriveOdometry swerveOdometry;


### PR DESCRIPTION
We found that the module offsets would keep getting lost when using MK4i modules because the resetModulesToAbsolute wasn't being called. This PR calls `resetModulesToAbsolute` after a 1-second delay to fix this issue.